### PR TITLE
DAC6-3331: Update AdminOnlyAuthAction to allow Agents with User role

### DIFF
--- a/app/uk/gov/hmrc/crsfatcaregistration/auth/AdminOnlyAuthAction.scala
+++ b/app/uk/gov/hmrc/crsfatcaregistration/auth/AdminOnlyAuthAction.scala
@@ -63,8 +63,7 @@ class AdminOnlyAuthActionImpl @Inject() (
     credentialRole: Option[CredentialRole]
   ): Boolean =
     affinityGroup match {
-      case Some(Agent) => false
-      case Some(Organisation) =>
+      case Some(Organisation) | Some(Agent) =>
         credentialRole.fold(false)(
           cr => cr == User
         )

--- a/test/uk/gov/hmrc/crsfatcaregistration/auth/AdminOnlyAuthActionSpec.scala
+++ b/test/uk/gov/hmrc/crsfatcaregistration/auth/AdminOnlyAuthActionSpec.scala
@@ -86,7 +86,7 @@ class AdminOnlyAuthActionSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
     }
 
     "the user is logged in as Agent" must {
-      "must return UNAUTHORIZED request" in {
+      "must return request" in {
         val retrieval: AuthRetrievals = Some(Agent) ~ Some(User)
         when(
           mockAuthConnector
@@ -100,7 +100,7 @@ class AdminOnlyAuthActionSpec extends PlaySpec with GuiceOneAppPerSuite with Moc
         val controller = new Harness(authAction)
 
         val result = controller.onPageLoad()(FakeRequest("", ""))
-        status(result) mustBe UNAUTHORIZED
+        status(result) mustBe OK
       }
     }
 


### PR DESCRIPTION
Refactored AdminOnlyAuthAction to permit Agents with a User credential role, aligning their access rights with Organisations. Updated corresponding test cases to reflect this change in authorization logic.