### PR TITLE
DAC6-3457: Change regime to CRFA

### DIFF
--- a/app/uk/gov/hmrc/crsfatcaregistration/models/RequestCommon.scala
+++ b/app/uk/gov/hmrc/crsfatcaregistration/models/RequestCommon.scala
@@ -34,7 +34,7 @@ object RequestCommon {
 
   def apply: RequestCommon = {
     val clock           = Clock.systemDefaultZone()
-    val regime: String  = "CRSFATCA"
+    val regime: String  = "CRFA"
     val acknRef: String = randomUUID().toString.replaceAll("-", "") // uuids are 36 and spec demands 32
     // Format: ISO 8601 YYYY-MM-DDTHH:mm:ssZ e.g. 2020-09-23T16:12:11Z
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")

--- a/test-common/uk/gov/hmrc/crsfatcaregistration/generators/ModelGenerators.scala
+++ b/test-common/uk/gov/hmrc/crsfatcaregistration/generators/ModelGenerators.scala
@@ -77,7 +77,7 @@ trait ModelGenerators {
 
     } yield RequestCommon(
       receiptDate = receiptDate,
-      regime = "CRSFATCA",
+      regime = "CRFA",
       acknowledgementReference = acknowledgementRef,
       None
     )


### PR DESCRIPTION
Updated the regime field from "CRSFATCA" to "CRFA" in RequestCommon model class and its generator. This ensures consistency across the application and aligns with the latest protocol standards.